### PR TITLE
Measure DB read and Redis read latency, Add test to compare

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <url/>
     </scm>
     <properties>
-        <java.version>21</java.version>
+        <java.version>23</java.version>
     </properties>
     <dependencies>
         <dependency>
@@ -66,6 +66,12 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.38</version> <!-- or latest -->
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,5 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.cache.type=redis
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
+
+logging.level.root=INFO

--- a/src/test/java/com/techie/springbootrediscache/SpringBootRedisCacheApplicationTests.java
+++ b/src/test/java/com/techie/springbootrediscache/SpringBootRedisCacheApplicationTests.java
@@ -5,6 +5,9 @@ import com.techie.springbootrediscache.dto.ProductDto;
 import com.techie.springbootrediscache.entity.Product;
 import com.techie.springbootrediscache.repository.ProductRepository;
 import com.techie.springbootrediscache.service.ProductService;
+import jakarta.validation.constraints.AssertTrue;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
 @AutoConfigureMockMvc
+@Slf4j
 class SpringBootRedisCacheApplicationTests {
 
     @Container
@@ -90,17 +94,25 @@ class SpringBootRedisCacheApplicationTests {
         productRepository.save(product);
 
         // Step 2: Fetch product
+        long start = System.currentTimeMillis();
         mockMvc.perform(MockMvcRequestBuilders.get("/api/product/" + product.getId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("Phone"));
+        long end = System.currentTimeMillis();
 
         Mockito.verify(productRepositorySpy, Mockito.times(1)).findById(product.getId());
+        final long dbReadLatency = end - start;
 
         Mockito.clearInvocations(productRepositorySpy);
-
+        start = System.currentTimeMillis();
         mockMvc.perform(MockMvcRequestBuilders.get("/api/product/" + product.getId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("Phone"));
+        end = System.currentTimeMillis();
+        final long redisReadLatency = end - start;
+
+        log.info("Time taken to read from db is {} ms, and from redis cache is {} ms", dbReadLatency, redisReadLatency);
+        Assertions.assertTrue(dbReadLatency > redisReadLatency);
 
         Mockito.verify(productRepositorySpy, Mockito.times(0)).findById(product.getId());
     }


### PR DESCRIPTION
This pull request does the following 2 things: 
1. Use Java 23 & Add Lombok for logging in the integration tests. (The dependency did not work for me on with Java 21)
2. Measure the latency of DB read versus redis cache read. DB read should take more time 
```
2025-11-08T17:50:22.609Z  INFO 65789 t.s.SpringBootRedisCacheApplicationTests : 
Time taken to read from db is 194 ms, and from redis cache is 13 ms
```
Test passes: 
<img width="590" height="65" alt="image" src="https://github.com/user-attachments/assets/a12145d0-dd72-45d0-b30e-4ba19edca19b" />
